### PR TITLE
Fix "View page source" links to be GitHub page links

### DIFF
--- a/docs/source/_templates/breadcrumbs.html
+++ b/docs/source/_templates/breadcrumbs.html
@@ -24,6 +24,13 @@
 {% set display_gitlab = True %}
 {% endif %}
 
+{# Configure GitHub variables that aren't automatically set in the Project Athena environment. #}
+{% set display_github = True %}
+{% set github_user = 'kasenvr' %}
+{% set github_repo = 'athena-docs-sphinx' %}
+{% set github_version = 'master' %}
+{% set conf_py_path = '/docs/source/' %}
+
 <div role="navigation" aria-label="breadcrumbs navigation">
 
   <ul class="wy-breadcrumbs">
@@ -37,10 +44,10 @@
     {% block breadcrumbs_aside %}
       <li class="wy-breadcrumbs-aside">
         {% if hasdoc(pagename) %}
-            {% if display_github %}
+          {% if display_github %}
             {% if check_meta and 'github_url' in meta %}
               <!-- User defined GitHub URL -->
-              <a href="{{ meta['github_url'] }}" class="fa fa-github"></a><a href="{{ meta['github_url'] }}>{{ _('Edit on GitHub') }}</a>
+              <a href="{{ meta['github_url'] }}" class="fa fa-github"></a><a href="{{ meta['github_url'] }}">{{ _('Edit on GitHub') }}</a>
             {% else %}
               <a href="https://{{ github_host|default("github.com") }}/{{ github_user }}/{{ github_repo }}/{{ theme_vcs_pageview_mode|default("blob") }}/{{ github_version }}{{ conf_py_path }}{{ pagename }}{{ suffix }}" class="fa fa-github"></a><a href="https://{{ github_host|default("github.com") }}/{{ github_user }}/{{ github_repo }}/{{ theme_vcs_pageview_mode|default("blob") }}/{{ github_version }}{{ conf_py_path }}{{ pagename }}{{ suffix }}"> {{ _('Edit on GitHub') }}</a>
             {% endif %}


### PR DESCRIPTION
Instead of a "View page source" link at the top right of each page, display a "Edit on GitHub" link (same as how High Fidelity had) that takes the user to that page on GitHub, e.g., https://github.com/kasenvr/athena-docs-sphinx/blob/master/docs/source/create/tools.rst for the "Create Tools" page.

Issue: https://github.com/kasenvr/athena-docs-sphinx/issues/7